### PR TITLE
Update semconv for coldstart processor and telemetryApi receiver

### DIFF
--- a/collector/processor/coldstartprocessor/processor.go
+++ b/collector/processor/coldstartprocessor/processor.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
-	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/zap"
 )
 
@@ -67,7 +67,7 @@ func (p *coldstartProcessor) processTraces(ctx context.Context, td ptrace.Traces
 						return false
 					}
 				}
-				if _, ok := span.Attributes().Get(semconv.AttributeFaaSExecution); ok {
+				if _, ok := span.Attributes().Get(semconv.AttributeFaaSInvocationID); ok {
 					if p.coldstartSpan == nil {
 						p.faasExecution = &faasExecution{
 							span:     ptrace.NewSpan(),

--- a/collector/processor/coldstartprocessor/processor_test.go
+++ b/collector/processor/coldstartprocessor/processor_test.go
@@ -33,7 +33,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/processor/processortest"
-	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/multierr"
 )
 
@@ -225,12 +225,12 @@ func addExecutionSpan(td ptrace.Traces, id pcommon.TraceID) {
 	ss.Scope().SetName("app/execution")
 	span := ss.Spans().AppendEmpty()
 	span.SetTraceID(id)
-	span.Attributes().PutStr(semconv.AttributeFaaSExecution, "af9d5aa4-a685-4c5f-a22b-444f80b3cc28")
+	span.Attributes().PutStr(semconv.AttributeFaaSInvocationID, "af9d5aa4-a685-4c5f-a22b-444f80b3cc28")
 }
 
 func executionSpan(span ptrace.Span, id pcommon.TraceID) {
 	span.SetTraceID(id)
-	span.Attributes().PutStr(semconv.AttributeFaaSExecution, "af9d5aa4-a685-4c5f-a22b-444f80b3cc28")
+	span.Attributes().PutStr(semconv.AttributeFaaSInvocationID, "af9d5aa4-a685-4c5f-a22b-444f80b3cc28")
 }
 
 func initializationSpan(span ptrace.Span, id pcommon.TraceID) {

--- a/collector/receiver/telemetryapireceiver/receiver.go
+++ b/collector/receiver/telemetryapireceiver/receiver.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver"
-	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-lambda/collector/internal/telemetryapi"
@@ -196,10 +196,10 @@ func newTelemetryAPIReceiver(
 	envResourceMap := map[string]string{
 		"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": semconv.AttributeFaaSMaxMemory,
 		"AWS_LAMBDA_FUNCTION_VERSION":     semconv.AttributeFaaSVersion,
-		"AWS_REGION":                      semconv.AttributeFaaSInvokedRegion,
+		"AWS_REGION":                      semconv.AttributeCloudRegion,
 	}
 	r := pcommon.NewResource()
-	r.Attributes().PutStr(semconv.AttributeFaaSInvokedProvider, semconv.AttributeFaaSInvokedProviderAWS)
+	r.Attributes().PutStr(semconv.AttributeCloudProvider, semconv.AttributeCloudProviderAWS)
 	if val, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_NAME"); ok {
 		r.Attributes().PutStr(semconv.AttributeServiceName, val)
 		r.Attributes().PutStr(semconv.AttributeFaaSName, val)


### PR DESCRIPTION
* Align with the latest conventions. Mainly for `faas.execution` -> `faas.invocation_id`